### PR TITLE
Add iombian-button-handler

### DIFF
--- a/services/iombian-button-handler/0.1.0/docker-compose.yaml
+++ b/services/iombian-button-handler/0.1.0/docker-compose.yaml
@@ -22,12 +22,12 @@ services:
       com.iombian-button-handler.env.BUTTON_EVENTS_PORT.name: "Button events port"
       com.iombian-button-handler.env.BUTTON_EVENTS_PORT.description: "Port where button events are published."
       com.iombian-button-handler.env.BUTTON_EVENTS_PORT.type: "integer:1024;65535"
-      com.iombian-button-handler.env.BUTTON_EVENTS_PORT.default: 5556
+      com.iombian-button-handler.env.BUTTON_EVENTS_PORT.default: "5556"
 
       com.iombian-button-handler.env.BUTTON_PIN.name: "Button pin"
       com.iombian-button-handler.env.BUTTON_PIN.description: "The GPIO pin where the button is connected."
       com.iombian-button-handler.env.BUTTON_PIN.type: "integer:1;40"
-      com.iombian-button-handler.env.BUTTON_PIN.default: 3
+      com.iombian-button-handler.env.BUTTON_PIN.default: "3"
 
       com.iombian-button-handler.env.LOG_LEVEL.name: "Log level"
       com.iombian-button-handler.env.LOG_LEVEL.description: "Log level of the application (INFO, DEBUG, ...)."


### PR DESCRIPTION
Add iombian-button-handler to the marketplace.

This service handles the raspberry GPIO button pin.
Then, it publishes the detected button press with ZeroMQ.

This service uses [iombian-button-handler](https://github.com/Tknika/iombian-button-handler)