### PR TITLE
Add iombian shutdown handler

### DIFF
--- a/servcies/iombian-shutdown-handler/0.1.0/docker-compose.yaml
+++ b/servcies/iombian-shutdown-handler/0.1.0/docker-compose.yaml
@@ -22,7 +22,7 @@ services:
 
       com.iombian-shutdown-handler.env.SHUTDOWN_EVENT.name: "Shutdown event"
       com.iombian-shutdown-handler.env.SHUTDOWN_EVENT.description: "Event that will trigger the device to shutdown."
-      com.iombian-shutdown-handler.env.SHUTDOWN_EVENT.type: "string"
+      com.iombian-shutdown-handler.env.SHUTDOWN_EVENT.type: "enum:double_click,triple_click,many_click,long_click,long_long_click"
       com.iombian-shutdown-handler.env.SHUTDOWN_EVENT.default: "long_click"
 
       com.iombian-shutdown-handler.env.BUTTON_EVENTS_PORT.name: "Button events port"


### PR DESCRIPTION
Add [iombian-shutdown-handler](https://github.com/Tknika/iombian-shutdown-handler) to the marketplace.

This service listens for button events and publishes the shutdown command when a specific button event is received.