### PR TITLE
Add iombian config file handler

### DIFF
--- a/services/iombian-config-file-handler/0.1.0/docker-compose.yaml
+++ b/services/iombian-config-file-handler/0.1.0/docker-compose.yaml
@@ -25,13 +25,13 @@ services:
       com.iombian-config-file-handler.service.documentation_url: ""
 
       com.iombian-config-file-handler.env.CONFIG_PORT.name: "Configuration port"
-      com.iombian-config-file-handler.env.CONFIG_PORT.description: "Port though which other services will access the configuration."
+      com.iombian-config-file-handler.env.CONFIG_PORT.description: "Port through which other services will set and access the configuration."
       com.iombian-config-file-handler.env.CONFIG_PORT.type: "integer:1024;65535"
       com.iombian-config-file-handler.env.CONFIG_PORT.default: "5555"
 
       com.iombian-config-file-handler.env.RESET_EVENT.name: "Reset event"
       com.iombian-config-file-handler.env.RESET_EVENT.description: "Button event that will trigger the device to reset."
-      com.iombian-config-file-handler.env.RESET_EVENT.type: "string"
+      com.iombian-config-file-handler.env.RESET_EVENT.type: "enum:double_click,triple_click,many_click,long_click,long_long_click"
       com.iombian-config-file-handler.env.RESET_EVENT.default: "long_long_click"
 
       com.iombian-config-file-handler.env.BUTTON_EVENTS_PORT.name: "Button events port"


### PR DESCRIPTION
Add [iombian-config-file-handler](https://github.com/Tknika/iombian-config-file-handler) service to the marketplace.

This service handles the configuration of the IoMBian.
All the services have to ask to this service to get the configuration.

It also listens to a button event to change the configuration and restart the IoMBian.