### PR TITLE
Remove default env variable

### DIFF
--- a/services/iombian-button-handler/0.1.0/docker-compose.yaml
+++ b/services/iombian-button-handler/0.1.0/docker-compose.yaml
@@ -7,10 +7,10 @@ services:
     networks:
       - iombian-internal-services
     ports:
-      - ${BUTTON_EVENTS_PORT:-5556}:5556
+      - ${BUTTON_EVENTS_PORT}:5556
     environment:
-      BUTTON_PIN: ${BUTTON_PIN:-3}
-      LOG_LEVEL: ${LOG_LEVEL:-INFO}
+      BUTTON_PIN: ${BUTTON_PIN}
+      LOG_LEVEL: ${LOG_LEVEL}
     labels:
       com.iombian-button-handler.service.name: "IoMBian Button Handler"
       com.iombian-button-handler.service.author: "Aitor Castaño"

--- a/services/iombian-config-file-handler/0.1.0/docker-compose.yaml
+++ b/services/iombian-config-file-handler/0.1.0/docker-compose.yaml
@@ -8,14 +8,14 @@ services:
     networks:
       - iombian-internal-services 
     ports:
-      - ${CONFIG_PORT:-5555}:5555
+      - ${CONFIG_PORT}:5555
     environment:
-      RESET_EVENT: ${RESET_EVENT:-long_long_click}
+      RESET_EVENT: ${RESET_EVENT}
       BUTTON_EVENTS_HOST: iombian-button-handler
-      BUTTON_EVENTS_PORT: ${BUTTON_EVENTS_PORT:-5556}
+      BUTTON_EVENTS_PORT: ${BUTTON_EVENTS_PORT}
       SHUTDOWN_SERVICE_HOST: iombian-shutdown-service
-      SHUTDOWN_SERVICE_PORT: ${SHUTDOWN_SERVICE_PORT:-5558}
-      LOG_LEVEL: ${LOG_LEVEL:-INFO}
+      SHUTDOWN_SERVICE_PORT: ${SHUTDOWN_SERVICE_PORT}
+      LOG_LEVEL: ${LOG_LEVEL}
     labels:
       com.iombian-config-file-handler.service.name: "IoMBian Config File Handler"
       com.iombian-config-file-handler.service.author: "Aitor Castaño"

--- a/services/iombian-shudown-services/0.1.0/docker-compose.yaml
+++ b/services/iombian-shudown-services/0.1.0/docker-compose.yaml
@@ -11,9 +11,9 @@ services:
     networks:
       - iombian-internal-services
     ports:
-      - ${SHUTDOWN_SERVICE_PORT:-5558}:5558
+      - ${SHUTDOWN_SERVICE_PORT}:5558
     environment:
-      LOG_LEVEL: ${LOG_LEVEL:-INFO}
+      LOG_LEVEL: ${LOG_LEVEL}
     labels:
       com.iombian-shutdown-service.service.name: "IoMBian Shutdown Service"
       com.iombian-shutdown-service.service.author: "Aitor Castaño"

--- a/services/iombian-shutdown-handler/0.1.0/docker-compose.yaml
+++ b/services/iombian-shutdown-handler/0.1.0/docker-compose.yaml
@@ -6,12 +6,12 @@ services:
     networks:
       - iombian-internal-services
     environment:
-      SHUTDOWN_EVENT: ${SHUTDOWN_EVENT:-long_click}
+      SHUTDOWN_EVENT: ${SHUTDOWN_EVENT}
       BUTTON_EVENTS_HOST: iombian-button-handler
-      BUTTON_EVENTS_PORT: ${BUTTON_EVENTS_PORT:-5556}
+      BUTTON_EVENTS_PORT: ${BUTTON_EVENTS_PORT}
       SHUTDOWN_SERVICE_HOST: iombian-shutdown-service
-      SHUTDOWN_SERVICE_PORT: ${SHUTDOWN_SERVICE_PORT:-5558}
-      LOG_LEVEL: ${LOG_LEVEL:-INFO}
+      SHUTDOWN_SERVICE_PORT: ${SHUTDOWN_SERVICE_PORT}
+      LOG_LEVEL: ${LOG_LEVEL}
     labels:
       com.iombian-shutdown-handler.service.name: "IoMBian Shutdown Handler"
       com.iombian-shutdown-handler.service.author: "Aitor Castaño"


### PR DESCRIPTION
The default variable is already defined in the labels. The default values will be passed in a .env file if no value is set, so there is no need to define a default value in the ${} environment variables.