### PR TITLE
Read env values as str

### DIFF
--- a/.github/scripts/compose_validator.py
+++ b/.github/scripts/compose_validator.py
@@ -231,7 +231,7 @@ class Service(BaseModel):
                 env_vars = get_vars_from_string(env)
                 all_vars += env_vars
 
-                env_value = self.environment[env]
+                env_value = str(self.environment[env])
                 env_value_vars = get_vars_from_string(env_value)
                 all_vars += env_value_vars
 


### PR DESCRIPTION
Fix error when the checked regex string is not a string. apply str() so it always is a str.