### PR TITLE
Add order to env labels

### DIFF
--- a/.github/scripts/parse_labels.py
+++ b/.github/scripts/parse_labels.py
@@ -20,6 +20,7 @@ def parse_labels(docker_compose: dict, service_name: str) -> Dict[str, ParsedLab
     """Given the docker-compose in dict/json form, return the label information."""
     services = docker_compose["services"]
     parsed_labels = {}
+    env_order = 0
 
     for service in services:
         service_labels = {}
@@ -45,6 +46,8 @@ def parse_labels(docker_compose: dict, service_name: str) -> Dict[str, ParsedLab
 
                 if not service_labels["envs"].get(env_name):
                     service_labels["envs"][env_name] = {}
+                    service_labels["envs"][env_name]["order"] = str(env_order)
+                    env_order += 1
 
                 env_metadata_key = splitted_label[4]
                 service_labels["envs"][env_name][env_metadata_key] = value

--- a/.github/scripts/parse_labels.py
+++ b/.github/scripts/parse_labels.py
@@ -17,7 +17,7 @@ class ParsedLabels(TypedDict):
 
 
 def parse_labels(docker_compose: dict, service_name: str) -> Dict[str, ParsedLabels]:
-    """Given the docker-compose in dict/json form, return the label information."""
+    """Given the docker-compose in dict/json form, return the label information and label order."""
     services = docker_compose["services"]
     parsed_labels = {}
     env_order = 0

--- a/standard.md
+++ b/standard.md
@@ -1,6 +1,6 @@
 # IoMBian Marketplace Standard
 
-### 0.1.2
+### 0.1.3
 
 This is the standard to follow when uploading services to the IoMBian Services Marketplace. 
 
@@ -155,6 +155,7 @@ com.iombian-button-handler.service.documentation_url: "https://github.com/Tknika
 The environment variables will also have some tags with metadata.
 This metadata will be used by the iombian-configurator to generate the forms needed for input.
 Like this, you can change some values of a service from the configurator.
+The form inputs will appear in the same order in which the labels appear in the file.
 
 The labels will refer to the environment variables defined with ${}, not the ones in the environment section.
 This means, having this example:

--- a/standard.md
+++ b/standard.md
@@ -246,7 +246,7 @@ services:
             com.iombian-example-service.service.changelog: "First release."
             com.iombian-example-service.service.documentation_url: "url/to/documentation"
 
-            com.iombian-example-service.env.PORT_ENV.name: "Port env"
+            com.iombian-example-service.env.BUTTON_EVENTS_PORT.name: "Port env"
             com.iombian-example-service.env.BUTTON_EVENTS_PORT.description: "Example functionality of Port env."
             com.iombian-example-service.env.BUTTON_EVENTS_PORT.type: "integer"
             com.iombian-example-service.env.BUTTON_EVENTS_PORT.default: "5555"


### PR DESCRIPTION
Add an order parameter to the env labels depending on the order on which the env labels appear in the docker compose file.
If one env label appears before another, that label will appear before the other in the IoMBian configurator envs form.